### PR TITLE
avoid uncaught

### DIFF
--- a/lib/middleware/resume.js
+++ b/lib/middleware/resume.js
@@ -32,6 +32,7 @@ module.exports = function(flows, store, options) {
       
       store.load(req, state.prev, function(err, state) {
         if (err) { return next(err); }
+        if (!state) { return next(new Error("Cannot resume unnamed flow (state not found)")); }
         
         req.state = state;
         


### PR DESCRIPTION
if `state` is undefined, it will throw uncaught.