### PR TITLE
Add expiration functionality.

### DIFF
--- a/lib/middleware/clean.js
+++ b/lib/middleware/clean.js
@@ -32,7 +32,7 @@ module.exports = function(store, options) {
         if (limit && (states.length - i) >= limit) {
           store.destroy(req, state.handle, iter);
         } else if (ttl && age > ttl) {
-          store.destroy(req, state.handle, iter);
+          store.expire(req, state.handle, iter);
         } else {
           iter();
         }

--- a/lib/stores/session.js
+++ b/lib/stores/session.js
@@ -42,8 +42,11 @@ SessionStore.prototype.load = function(req, h, options, cb) {
 
   var state = clone(req.session[key][h]);
   state.handle = h;
-  
-  if (options.destroy === true) {
+
+  if (state.expired) {
+    this.destroy(req, h, function(){});
+    return cb(new Error('login process has timed out, please try again'));
+  } else if (options.destroy === true) {
     this.destroy(req, h, function(){});
     return cb(null, state);
   } else {
@@ -89,6 +92,16 @@ SessionStore.prototype.destroy = function(req, h, cb) {
   if (Object.keys(req.session[key]).length == 0) {
     delete req.session[key];
   }
+  return cb();
+}
+
+SessionStore.prototype.expire = function(req, h, cb) {
+  var key = this._key;
+  if (!req.session || !req.session[key] || !req.session[key][h]) {
+    return cb();
+  }
+
+  req.session[key][h].expired = true;
   return cb();
 }
 


### PR DESCRIPTION
This expires instead of deletes a state if it has timed out, so that upon load an expiration error message may be shown to the user instead of a 'state not found'. When that expiration error occurs, the state is then destroyed.

No change is made to the limit functionality - if too many concurrent logins are started it will still cause a state not found error. This should be uncommon for users working with properly functioning clients, and is necessary so that an adversary cannot try and overload our storage capacity by making an extreme number of login requests.