### PR TITLE
Don't attempt to load previously deleted (expired) sessions.

### DIFF
--- a/lib/errors/expiredstateerror.js
+++ b/lib/errors/expiredstateerror.js
@@ -1,0 +1,19 @@
+/**
+ * `ExpiredStateError` error.
+ */
+function ExpiredStateError(message, state) {
+  Error.call(this);
+  this.message = message;
+  this.state = state;
+}
+
+/**
+ * Inherit from `Error`.
+ */
+ExpiredStateError.prototype.__proto__ = Error.prototype;
+
+
+/**
+ * Expose `ExpiredStateError`.
+ */
+module.exports = ExpiredStateError;

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,3 +5,5 @@ exports.load = require('./middleware/load');
 exports.resume = require('./middleware/resume');
 exports.resumeError = require('./middleware/resumeError');
 exports.clean = require('./middleware/clean');
+
+exports.ExpiredStateError = require('./errors/expiredstateerror');

--- a/lib/middleware/resumeError.js
+++ b/lib/middleware/resumeError.js
@@ -1,5 +1,5 @@
-var SessionStore = require('../stores/session');
-
+var SessionStore      = require('../stores/session');
+var ExpiredStateError = require('../errors/expiredstateerror');
 
 module.exports = function(flows, store, options) {
   options = options || {};
@@ -28,7 +28,11 @@ module.exports = function(flows, store, options) {
         // expected to implement default behavior for handling the error.
         return next(err);
       }
-      
+
+      // Don't try and load the previous state if it's antecedent removal was the cause
+      // of the error that led to this processing in the first place.
+      if (err instanceof ExpiredStateError && err.state.handle === state.prev) { return next(err); };
+
       var yieldState = state;
       store.load(req, state.prev, function(ierr, state) {
         if (ierr) { return next(ierr); }

--- a/lib/stores/session.js
+++ b/lib/stores/session.js
@@ -1,6 +1,7 @@
 var uid = require('uid-safe').sync;
 var clone = require('clone');
 
+var ExpiredStateError = require('../errors/expiredstateerror');
 
 function SessionStore(options) {
   options = options || {};
@@ -45,7 +46,7 @@ SessionStore.prototype.load = function(req, h, options, cb) {
 
   if (state.expired) {
     this.destroy(req, h, function(){});
-    return cb(new Error('login process has timed out, please try again'));
+    return cb(new ExpiredStateError('login process has timed out, please try again', state));
   } else if (options.destroy === true) {
     this.destroy(req, h, function(){});
     return cb(null, state);


### PR DESCRIPTION
This has been the cause of some issues when an expired state is loaded more than once after it's expiration - this causes the correct error thrown in that circumstance to be stomped by a `cannot resume unnamed flow` error when the later attempts to load are unable to find the now deleted state.

The PR solves this by making the expiration error stand out, and skipping the reloading phase in that circumstance.