### PR TITLE
Add support for default transition behavior.

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -24,7 +24,9 @@ Manager.prototype.transition = function(name, from, trans) {
   }
   
   trans = trans && flatten(Array.prototype.slice.call(trans, 0));
-  this._stt[name + '|' + from] = trans;
+
+  var reg = (name) ? name + '|' + from : from;
+  this._stt[reg] = trans;
 }
 
 Manager.prototype.goto = function(name, options, req, res, next) {
@@ -68,7 +70,8 @@ Manager.prototype._resume = function(name, err, req, res, next) {
 }
 
 Manager.prototype._transition = function(name, from, err, req, res, next) {
-  var trans = this._stt[name + '|' + from];
+  var reg = (name) ? name + '|' + from : from;
+  var trans = this._stt[reg];
   if (!trans) { return next(err); }
   
   dispatch(trans)(err, req, res, next);

--- a/lib/middleware/complete.js
+++ b/lib/middleware/complete.js
@@ -15,26 +15,37 @@ module.exports = function(dispatcher, store, options) {
   
   return function completeState(req, res, next) {
     function dispatch(name) {
-      if (!name) { return next(new Error("Cannot resume unnamed flow")); }
       
       function cont(err) {
+        if (!name) { return next(new Error("Cannot resume unnamed flow")); }
+        
         // TODO: Test case for transition error
         dispatcher._resume(name, err, req, res, next);
       }
-      
-      var yname = from || (req.yieldState && req.yieldState.name);
-      if (yname) {
-        dispatcher._transition(name, yname, null, req, res, cont);
+
+      // If we have a name, then there is a previous state to transition through
+      // and then resume. If we do not have a name then there is no previous state
+      // and we should look for a default transition that will then pass off to the
+      // `next` middleware, which will be expected to provide default behavior.
+      var yname, post;
+      if (name) {
+        yname = from || (req.yieldState && req.yieldState.name);
+        post  = cont;
       } else {
-        cont();
+        yname = from || (req.state && req.state.name);
+        post  = next;
+      }
+      
+      if (yname) {
+        dispatcher._transition(name, yname, null, req, res, post);
+      } else {
+        post();
       }
     }
     
     function proceed(h, ystate) {
       if (!h) {
-        // No state to resume.  `next` middleware is expected to implement
-        // default behavior for responding to the request.
-        return next();
+        return dispatch();
       }
       
       store.load(req, h, function(err, state) {

--- a/lib/middleware/completeError.js
+++ b/lib/middleware/completeError.js
@@ -18,26 +18,37 @@ module.exports = function(dispatcher, store, options) {
     if (req._skipResumeError) { return next(err); }
     
     function dispatch(name) {
-      if (!name) { return next(new Error("Cannot resume unnamed flow")); }
       
       function cont(err) {
+        if (!name) { return next(new Error("Cannot resume unnamed flow")); }
+        
         dispatcher._resume(name, err, req, res, next);
       }
       
-      var yname = from || (req.yieldState && req.yieldState.name);
+      // If we have a name, then there is a previous state to transition through
+      // and then resume. If we do not have a name then there is no previous state
+      // and we should look for a default transition that will then pass off to the
+      // `next` middleware, which will be expected to provide default error behavior.
+      var yname, post;
+      if (name) {
+        yname = from || (req.yieldState && req.yieldState.name);
+        post  = cont;
+      } else {
+        yname = from || (req.state && req.state.name);
+        post  = next;
+      }
+      
       if (yname) {
         // TODO: Make sure transition errors get plumbed through correctly
-        dispatcher._transition(name, yname, err, req, res, cont);
+        dispatcher._transition(name, yname, err, req, res, post);
       } else {
-        cont(err);
+        post(err);
       }
     }
     
     function proceed(h, ystate) {
       if (!h) {
-        // No state to resume.  `next` middleware is expected to implement
-        // default behavior for responding to the request.
-        return next(err);
+        return dispatch();
       }
       
       store.load(req, h, function(ierr, state) {

--- a/test/middleware/complete.test.js
+++ b/test/middleware/complete.test.js
@@ -530,8 +530,11 @@ describe('middleware/complete', function() {
       expect(store.load).to.not.have.been.called;
     });
     
-    it('should not call dispatcher#_transition', function() {
-      expect(dispatcher._transition).to.not.have.been.called;
+    it('should call dispatcher#_transition', function() {
+      expect(dispatcher._transition).to.have.been.calledOnce;
+      var call = dispatcher._transition.getCall(0);
+      expect(call.args[0]).to.equal(undefined);
+      expect(call.args[1]).to.equal('bar');
     });
     
     it('should not call dispatcher#_resume', function() {
@@ -613,8 +616,11 @@ describe('middleware/complete', function() {
       expect(call.args[1]).to.equal('22345678');
     });
     
-    it('should not call dispatcher#_transition', function() {
-      expect(dispatcher._transition).to.not.have.been.called;
+    it('should call dispatcher#_transition', function() {
+      expect(dispatcher._transition).to.have.been.calledOnce;
+      var call = dispatcher._transition.getCall(0);
+      expect(call.args[0]).to.equal(undefined);
+      expect(call.args[1]).to.equal('bar');
     });
     
     it('should not call dispatcher#_resume', function() {

--- a/test/middleware/completeError.test.js
+++ b/test/middleware/completeError.test.js
@@ -516,8 +516,12 @@ describe('middleware/completeError', function() {
       expect(store.load).to.not.have.been.called;
     });
     
-    it('should not call dispatcher#_transition', function() {
-      expect(dispatcher._transition).to.not.have.been.called;
+    it('should call dispatcher#_transition', function() {
+      expect(dispatcher._transition).to.have.been.calledOnce;
+      var call = dispatcher._transition.getCall(0);
+      expect(call.args[0]).to.equal(undefined);
+      expect(call.args[1]).to.equal('bar');
+      expect(call.args[2].message).to.equal('something went wrong');
     });
     
     it('should not call dispatcher#_resume', function() {
@@ -596,8 +600,12 @@ describe('middleware/completeError', function() {
       expect(call.args[1]).to.equal('22345678');
     });
     
-    it('should not call dispatcher#_transition', function() {
-      expect(dispatcher._transition).to.not.have.been.called;
+    it('should call dispatcher#_transition', function() {
+      expect(dispatcher._transition).to.have.been.calledOnce;
+      var call = dispatcher._transition.getCall(0);
+      expect(call.args[0]).to.equal(undefined);
+      expect(call.args[1]).to.equal('bar');
+      expect(call.args[2].message).to.equal('something went wrong');
     });
     
     it('should not call dispatcher#_resume', function() {


### PR DESCRIPTION
If you call `flowstate.complete()` on a state with no `prev` pointer, the library just hands off to the `next` callback in the express middleware chain. Although we want to maintain this behavior, we may also want to allow a transition to be loaded for this event. This would allow the library user to maintain consistency in terms of where functionality lies, if certain transition logic should occur for _all_ cases where a state is completed, independent of whether it has a predecessor.