### PR TITLE
Add support for multiple stores.

### DIFF
--- a/lib/middleware/complete.js
+++ b/lib/middleware/complete.js
@@ -1,7 +1,7 @@
 var SessionStore = require('../stores/session')
 var MissingStateError = require('../errors/missingstateerror');
 
-module.exports = function(dispatcher, store, options) {
+module.exports = function(dispatcher, stores, options) {
   if (typeof options == 'string') {
     options = { name: options };
   }
@@ -12,6 +12,15 @@ module.exports = function(dispatcher, store, options) {
     return (req.query && req.query.state) || (req.body && req.body.state);
   }
   
+  // NOTE: If `multi` mode is not indicated, then a single store has been
+  //       sent, which should be used for both the from and to states.
+  if (!options.multi) {
+    var store = stores;
+    stores = { fstore: store, tstore: store };
+  }
+  
+  if (!stores.fstore) { throw new Error('Complete middleware requires a `from` state store.'); }
+  if (!stores.tstore) { throw new Error('Complete middleware requires a `to` state store.'); }
   
   return function completeState(req, res, next) {
     function dispatch(name) {
@@ -37,7 +46,7 @@ module.exports = function(dispatcher, store, options) {
         return next();
       }
       
-      store.load(req, h, function(err, state) {
+      stores.tstore.load(req, h, function(err, state) {
         if (err) { return next(err); }
         if (!state) { return next(new MissingStateError("Failed to load previous state", ystate.prev)); }
         
@@ -62,7 +71,7 @@ module.exports = function(dispatcher, store, options) {
       // Remove the current state from any persistent storage, due to the
       // fact that it is complete.  Proceed to load the previous state (if any)
       // and resume processing.
-      store.destroy(req, state.handle, function(err) {
+      stores.fstore.destroy(req, state.handle, function(err) {
         if (err) { return next(err); }
         return proceed(state.prev, state);
       });

--- a/lib/middleware/completeError.js
+++ b/lib/middleware/completeError.js
@@ -2,7 +2,7 @@ var SessionStore      = require('../stores/session');
 var ExpiredStateError = require('../errors/expiredstateerror');
 
 
-module.exports = function(dispatcher, store, options) {
+module.exports = function(dispatcher, stores, options) {
   if (typeof options == 'string') {
     options = { from: options };
   }
@@ -13,6 +13,15 @@ module.exports = function(dispatcher, store, options) {
     return (req.query && req.query.state) || (req.body && req.body.state);
   }
   
+  // NOTE: If `multi` mode is not indicated, then a single store has been
+  //       sent, which should be used for both the from and to states.
+  if (!options.multi) {
+    var store = stores;
+    stores = { fstore: store, tstore: store };
+  }
+  
+  if (!stores.fstore) { throw new Error('CompleteError middleware requires a `from` state store.'); }
+  if (!stores.tstore) { throw new Error('CompleteError middleware requires a `to` state store.'); }
   
   return function completeStateError(err, req, res, next) {
     if (req._skipResumeError) { return next(err); }
@@ -40,7 +49,7 @@ module.exports = function(dispatcher, store, options) {
         return next(err);
       }
       
-      store.load(req, h, function(ierr, state) {
+      stores.tstore.load(req, h, function(ierr, state) {
         if (ierr) { return next(err); }
         if (!state) { return next(err); }
         
@@ -65,7 +74,7 @@ module.exports = function(dispatcher, store, options) {
       // Remove the current state from any persistent storage, due to the
       // fact that it is complete.  Proceed to load the previous state (if any)
       // and resume processing.
-      store.destroy(req, state.handle, function(ierr) {
+      stores.fstore.destroy(req, state.handle, function(ierr) {
         if (ierr) { return next(err); }
         
         // Don't try and load the previous state if it's antecedent removal was the cause

--- a/test/middleware/complete.test.js
+++ b/test/middleware/complete.test.js
@@ -107,6 +107,103 @@ describe('middleware/complete', function() {
     });
   }); // resuming previous state from current state
   
+  describe('resuming previous state from current state in `multi` mode', function() {
+    var dispatcher = {
+      _resume: function(name, err, req, res, next){ next(); },
+      _transition: function(name, from, err, req, res, next){ next(); }
+    };
+    var fstore = {
+      destroy: function(){}
+    };
+    var tstore = {
+      load: function(){}
+    };
+    
+    before(function() {
+      sinon.stub(tstore, 'load').yields(null, { name: 'foo', x: 1 });
+      sinon.stub(fstore, 'destroy').yields(null);
+      sinon.spy(dispatcher, '_resume');
+      sinon.spy(dispatcher, '_transition');
+    });
+    
+    after(function() {
+      dispatcher._transition.restore();
+      dispatcher._resume.restore();
+      fstore.destroy.restore();
+      tstore.load.restore();
+    });
+    
+    
+    var request, err;
+    before(function(done) {
+      chai.connect.use(completeState(dispatcher, { fstore: fstore, tstore: tstore }, { multi: true }))
+        .req(function(req) {
+          request = req;
+          request.state = { handle: '22345678', name: 'bar', y: 2, prev: '12345678' };
+        })
+        .next(function(e) {
+          err = e;
+          done();
+        })
+        .dispatch();
+    });
+    
+    it('should not error', function() {
+      expect(err).to.be.undefined;
+    });
+    
+    it('should set skip error flag', function() {
+      expect(request._skipResumeError).to.equal(true);
+    });
+    
+    it('should set state', function() {
+      expect(request.state).to.be.an('object');
+      expect(request.state).to.deep.equal({
+        name: 'foo',
+        x: 1
+      });
+    });
+    
+    it('should set yieldState', function() {
+      expect(request.yieldState).to.be.an('object');
+      expect(request.yieldState).to.deep.equal({
+        handle: '22345678',
+        name: 'bar',
+        y: 2,
+        prev: '12345678'
+      });
+    });
+    
+    it('should call fstore#destroy', function() {
+      expect(fstore.destroy).to.have.been.calledOnce;
+      var call = fstore.destroy.getCall(0);
+      expect(call.args[0]).to.equal(request);
+      expect(call.args[1]).to.equal('22345678');
+    });
+    
+    it('should call tstore#load', function() {
+      expect(tstore.load).to.have.been.calledOnce;
+      var call = tstore.load.getCall(0);
+      expect(call.args[0]).to.equal(request);
+      expect(call.args[1]).to.equal('12345678');
+    });
+    
+    it('should call dispatcher#_transition', function() {
+      expect(dispatcher._transition).to.have.been.calledOnce;
+      var call = dispatcher._transition.getCall(0);
+      expect(call.args[0]).to.equal('foo');
+      expect(call.args[1]).to.equal('bar');
+      expect(call.args[2]).to.be.null;
+    });
+    
+    it('should call dispatcher#_resume', function() {
+      expect(dispatcher._resume).to.have.been.calledOnce;
+      var call = dispatcher._resume.getCall(0);
+      expect(call.args[0]).to.equal('foo');
+      expect(call.args[1]).to.be.undefined;
+    });
+  }); // resuming previous state from current state in `multi` mode
+  
   describe('resuming previous state with non-yielding state', function() {
     var dispatcher = {
       _resume: function(name, err, req, res, next){ next(); },

--- a/test/middleware/completeError.test.js
+++ b/test/middleware/completeError.test.js
@@ -105,6 +105,101 @@ describe('middleware/completeError', function() {
     });
   }); // resuming previous state from current state
   
+  describe('resuming previous state from current state in `multi` mode', function() {
+    var dispatcher = {
+      _resume: function(name, err, req, res, next){ next(); },
+      _transition: function(name, from, err, req, res, next){ next(err); }
+    };
+    var fstore = {
+      destroy: function(){}
+    };
+    var tstore = {
+      load: function(){}
+    };
+    
+    before(function() {
+      sinon.stub(tstore, 'load').yields(null, { name: 'foo', x: 1 });
+      sinon.stub(fstore, 'destroy').yields(null);
+      sinon.spy(dispatcher, '_resume');
+      sinon.spy(dispatcher, '_transition');
+    });
+    
+    after(function() {
+      dispatcher._transition.restore();
+      dispatcher._resume.restore();
+      fstore.destroy.restore();
+      tstore.load.restore();
+    });
+    
+    
+    var request, err;
+    before(function(done) {
+      chai.connect.use(completeStateError(dispatcher, { fstore: fstore, tstore: tstore }, { multi: true }))
+        .req(function(req) {
+          request = req;
+          request.state = { handle: '22345678', name: 'bar', y: 2, prev: '12345678' };
+        })
+        .next(function(e) {
+          err = e;
+          done();
+        })
+        .dispatch(new Error('something went wrong'));
+    });
+    
+    it('should not error', function() {
+      expect(err).to.be.undefined;
+    });
+    
+    it('should set state', function() {
+      expect(request.state).to.be.an('object');
+      expect(request.state).to.deep.equal({
+        name: 'foo',
+        x: 1
+      });
+    });
+    
+    it('should set yieldState', function() {
+      expect(request.yieldState).to.be.an('object');
+      expect(request.yieldState).to.deep.equal({
+        handle: '22345678',
+        name: 'bar',
+        y: 2,
+        prev: '12345678'
+      });
+    });
+    
+    it('should call fstore#destroy', function() {
+      expect(fstore.destroy).to.have.been.calledOnce;
+      var call = fstore.destroy.getCall(0);
+      expect(call.args[0]).to.equal(request);
+      expect(call.args[1]).to.equal('22345678');
+    });
+    
+    it('should call tstore#load', function() {
+      expect(tstore.load).to.have.been.calledOnce;
+      var call = tstore.load.getCall(0);
+      expect(call.args[0]).to.equal(request);
+      expect(call.args[1]).to.equal('12345678');
+    });
+    
+    it('should call dispatcher#_transition', function() {
+      expect(dispatcher._transition).to.have.been.calledOnce;
+      var call = dispatcher._transition.getCall(0);
+      expect(call.args[0]).to.equal('foo');
+      expect(call.args[1]).to.equal('bar');
+      expect(call.args[2]).to.be.an.instanceOf(Error);
+      expect(call.args[2].message).to.equal('something went wrong');
+    });
+    
+    it('should call dispatcher#_resume', function() {
+      expect(dispatcher._resume).to.have.been.calledOnce;
+      var call = dispatcher._resume.getCall(0);
+      expect(call.args[0]).to.equal('foo');
+      expect(call.args[1]).to.be.an.instanceOf(Error);
+      expect(call.args[1].message).to.equal('something went wrong');
+    });
+  }); // resuming previous state from current state in `multi` mode
+  
   describe('resuming previous state with non-yielding state', function() {
     var dispatcher = {
       _resume: function(name, err, req, res, next){ next(); },


### PR DESCRIPTION
For the `complete` and `completeError` middleware, it might be possible that the two states in question are not stored in the same location and/or, more relevantly, are not accessed through the same database mapper. This PR allows those middlewares to be configured into a `multi` mode, in which the `fstore` (from store) used to destroy the yielding state, and the `tstore` (to store) used to load the resuming state, can be different. 